### PR TITLE
 Support laggards with Python <3.5

### DIFF
--- a/src/dscontrib/flawrence/experiment.py
+++ b/src/dscontrib/flawrence/experiment.py
@@ -32,11 +32,6 @@ class Experiment(object):
             conv_window_start_days=0,
             conv_window_length_days=7
         )
-
-
-    FIXME: don't filter by experiment map or join on branch, so we get data
-    from unenrolled people. Add an automatic column to the per-client data
-    that says whether the user unenrolled or changed branch.'
     """
     def __init__(self, experiment_slug, start_date, num_days_enrollment=None):
         self.experiment_slug = experiment_slug

--- a/src/dscontrib/flawrence/experiment.py
+++ b/src/dscontrib/flawrence/experiment.py
@@ -190,8 +190,7 @@ class Experiment(object):
         ).groupBy(
             enrollments.client_id, enrollments.branch
         ).agg(
-            *metric_list,
-            *self._get_telemetry_sanity_check_metrics(enrollments, df),
+            *(metric_list + self._get_telemetry_sanity_check_metrics(enrollments, df))
         )
         if keep_client_id:
             return res


### PR DESCRIPTION
Can't unpack multiple lists as function arguments in Python < 3.5 - which caused the CI jobs to fail.