### PR TITLE
Document and tidy experiment query code.

### DIFF
--- a/src/dscontrib/flawrence/experiment.py
+++ b/src/dscontrib/flawrence/experiment.py
@@ -32,82 +32,122 @@ class Experiment(object):
             conv_window_start_days=0,
             conv_window_length_days=7
         )
+
+    Args:
+        experiment_slug (str): Name of the study, used to identify
+            the enrollment events specific to this study.
+        start_date (str): e.g. '20190101'. First date on which enrollment
+            events were received.
+        num_days_enrollment (int, optional): Only include this many days
+            of enrollments. If `None` then use the maximum number of days
+            as determined by the metric's conversion window and today's date.
+
+    Attributes:
+        experiment_slug (str): Name of the study, used to identify
+            the enrollment events specific to this study.
+        start_date (str): e.g. '20190101'. First date on which enrollment
+            events were received.
+        num_days_enrollment (int, optional): Only include this many days
+            of enrollments. If `None` then use the maximum number of days
+            as determined by the metric's conversion window and today's date.
     """
     def __init__(self, experiment_slug, start_date, num_days_enrollment=None):
         self.experiment_slug = experiment_slug
         self.start_date = start_date
         self.num_days_enrollment = num_days_enrollment
 
-    def get_enrollments(self, spark):
+    def get_enrollments(self, spark, study_type='pref_flip'):
         """Return a DataFrame of enrolled clients.
 
-        This works for pref-flip studies.
+        This works for pref-flip and addon studies.
 
-        As of 2019/04/02, branch information isn't reliably available in
-        the `events` table for addon experiments: branch may be NULL for
-        all enrollments. The enrollment information for them is most
-        reliably available in `telemetry_shield_study_parquet`. So use
-        `get_enrollments_addon_exp()` for addon experiments until the
-        underlying issue is resolved.
+        The underlying queries are different for pref-flip vs addon
+        studies, because as of 2019/04/02, branch information isn't
+        reliably available in the `events` table for addon experiments:
+        branch may be NULL for all enrollments. The enrollment
+        information for them is most reliably available in
+        `telemetry_shield_study_parquet`. Once this issue is resolved,
+        we will probably start using normandy events for all desktop
+        studies.
         Ref: https://bugzilla.mozilla.org/show_bug.cgi?id=1536644
+
+        Args:
+            spark: The spark context.
+            study_type (str): One of the following strings:
+                - 'pref_flip'
+                - 'addon'
+
+        Returns:
+            A Spark DataFrame of enrollment data. One row per
+            enrollment. Columns:
+                - client_id (str)
+                - enrollment_date (str): e.g. '20190329'
+                - branch (str)
+        """
+        if study_type == 'pref_flip':
+            enrollments = self._get_enrollments_normandy_events(spark)
+
+        elif study_type == 'addon':
+            enrollments = self._get_enrollments_addon_exp(spark)
+
+        elif study_type == 'glean':
+            raise NotImplementedError
+
+        else:
+            raise ValueError("Unrecognized study_type: {}".format(study_type))
+
+        enrollments = enrollments.filter(
+            enrollments.enrollment_date >= self.start_date
+        )
+
+        if self.num_days_enrollment is not None:
+            enrollments = enrollments.filter(
+                enrollments.enrollment_date < add_days(
+                    self.start_date, self.num_days_enrollment
+                )
+            )
+
+        enrollments.cache()
+        F.broadcast(enrollments)
+
+        return enrollments
+
+    def _get_enrollments_normandy_events(self, spark):
+        """Return a DataFrame of enrolled clients for a pref-flip study.
+
+        Args:
+            spark: The spark context.
         """
         events = spark.table('events')
-        enrollments = events.filter(
-            events.submission_date_s3 >= self.start_date
-        ).filter(
+
+        return events.filter(
             events.event_category == 'normandy'
         ).filter(
             events.event_method == 'enroll'
         ).filter(
             events.event_string_value == self.experiment_slug
+        ).select(
+            events.client_id,
+            events.submission_date_s3.alias('enrollment_date'),
+            events.event_map_values.branch.alias('branch'),
         )
 
-        if self.num_days_enrollment is not None:
-            enrollments = enrollments.filter(
-                events.submission_date_s3 < add_days(
-                    self.start_date, self.num_days_enrollment
-                )
-            )
+    def _get_enrollments_addon_exp(self, spark):
+        """Return a DataFrame of enrolled clients for an addon study.
 
-        # TODO: should we also call `broadcast()`? Should we cache?
-        # TODO: should we filter clients enrolled multiple times?
-        return enrollments.select(
-            enrollments.client_id,
-            enrollments.submission_date_s3.alias('enrollment_date'),
-            enrollments.event_map_values.branch.alias('branch'),
-        )
-
-    def get_enrollments_addon_exp(self, spark):
-        """Temporary alternative to `get_enrollments` for addon experiments.
-
-        As of 2019/04/02, branch information isn't reliably available in
-        the `events` table for addon experiments: branch may be NULL for
-        all enrollments. The enrollment information for them is most
-        reliably available in `telemetry_shield_study_parquet`.
-        Ref: https://bugzilla.mozilla.org/show_bug.cgi?id=1536644
+        Args:
+            spark: The spark context.
         """
         tssp = spark.table('telemetry_shield_study_parquet')
-        enrollments = tssp.filter(
-            tssp.submission >= self.start_date
-        ).filter(
+
+        return tssp.filter(
             tssp.payload.data.study_state == 'enter'
         ).filter(
             tssp.payload.study_name == self.experiment_slug
-        )
-
-        if self.num_days_enrollment is not None:
-            enrollments = enrollments.filter(
-                tssp.submission < add_days(
-                    self.start_date, self.num_days_enrollment
-                )
-            )
-
-        # TODO: should we also call `broadcast()`? Should we cache?
-        # TODO: should we filter clients enrolled multiple times?
-        return enrollments.select(
-            enrollments.client_id,
-            enrollments.submission.alias('enrollment_date'),
-            enrollments.payload.branch.alias('branch'),
+        ).select(
+            tssp.client_id,
+            tssp.submission.alias('enrollment_date'),
+            tssp.payload.branch.alias('branch'),
         )
 
     def get_per_client_data(
@@ -117,34 +157,57 @@ class Experiment(object):
         """Return a DataFrame containing per-client metric values.
 
         Args:
-        - enrollments: A spark DataFrame of enrollments, like the one
-            returned by `self.get_enrollments()`.
-        - df: A spark DataFrame containing the data needed to calculate
-            the metrics. Could be `main_summary` or `clients_daily`.
-            _Don't_ use `experiments`; as of 2019/04/02 it drops data
-            collected after people self-unenroll, so unenrolling users
-            will appear to churn.
-        - metric_list: A list of columns that aggregate and compute
-            metrics, e.g.
+            enrollments: A spark DataFrame of enrollments, like the one
+                returned by `self.get_enrollments()`.
+            df: A spark DataFrame containing the data needed to calculate
+                the metrics. Could be `main_summary` or `clients_daily`.
+                _Don't_ use `experiments`; as of 2019/04/02 it drops data
+                collected after people self-unenroll, so unenrolling users
+                will appear to churn.
+            metric_list: A list of columns that aggregate and compute
+                metrics, e.g.
                 `[F.coalesce(F.sum(df.metric_name), F.lit(0)).alias('metric_name')]`
-        - today: A string representing the most recent day for which we
-            have incomplete data, e.g. '20190322'.
-        - conv_window_start_days: the start of the conversion window,
-            measured in 'days since the user enrolled'. We ignore data
-            collected outside this conversion window.
-        - conv_window_length_days: the length of the conversion window,
-            measured in days.
-        - keep_client_id: Whether to return a `client_id` column. Defaults
-            to False to reduce memory usage of the results.
+            today (str): The most recent day for which we have incomplete
+                data, e.g. '20190322'. Feel free to supply an older date
+                if the ETL is delayed or the experiment ended in the past.
+            conv_window_start_days (int): the start of the conversion window,
+                measured in 'days since the user enrolled'. We ignore data
+                collected outside this conversion window.
+            conv_window_length_days (int): the length of the conversion window,
+                measured in days.
+            keep_client_id (bool): Whether to return a `client_id` column.
+                Defaults to False to reduce memory usage of the results.
+
+        Returns:
+            A spark DataFrame of experiment data. One row per `client_id`.
+            One or two metadata columns, then one column per metric in
+            `metric_list`. Then one column per sanity-check metric.
+            Columns:
+                - client_id (str, optional): Not necessary for
+                    "happy path" analyses.
+                - branch (str): The client's branch
+                - [metric 1]: The client's value for the first metric in
+                    `metric_list`.
+                - ...
+                - [metric n]: The client's value for the nth (final)
+                    metric in `metric_list`.
+                - [sanity check 1]: The client's value for the first
+                    sanity check metric.
+                - ...
+                - [sanity check n]: The client's value for the last
+                    sanity check metric.
+
+            This format - the schema plus there being one row per
+            enrolled client, regardless of whether the client has data
+            in `df` - was agreed upon by the DS team, and is the
+            standard format for queried experimental data.
         """
         self._check_windows(today, conv_window_start_days + conv_window_length_days)
 
-        # TODO: can/should we switch from submission_date_s3 to when the
+        # TODO accuracy: can/should we switch from submission_date_s3 to when the
         # events actually happened?
         res = enrollments.filter(
             # Ignore clients that might convert in the future
-            # TODO: print debug info if it throws out enrollments
-            # when `num_days_enrollment is not None`?
             enrollments.enrollment_date < add_days(
                 today, -1 - conv_window_length_days - conv_window_start_days
             )
@@ -153,10 +216,10 @@ class Experiment(object):
                 df, today, conv_window_start_days, conv_window_length_days
             ),
             [
-                # TODO: would it be faster if we enforce a join on sample_id?
+                # TODO perf: would it be faster if we enforce a join on sample_id?
                 enrollments.client_id == df.client_id,
 
-                # TODO: once we can rely on
+                # TODO accuracy: once we can rely on
                 #   `df.experiments[self.experiment_slug]`
                 # existing even after unenrollment, we could start joining on
                 # branch to reduce problems associated with split client_ids.
@@ -165,7 +228,7 @@ class Experiment(object):
                 enrollments.enrollment_date <= df.submission_date_s3,
 
                 # Now do a more thorough pass filtering out irrelevant data:
-                # TODO: is there a more efficient way to do this?
+                # TODO perf: what is a more efficient way to do this?
                 (
                     (
                         F.unix_timestamp(df.submission_date_s3, 'yyyyMMdd')
@@ -198,11 +261,19 @@ class Experiment(object):
             return res.drop(enrollments.client_id)
 
     def _check_windows(self, today, min_days_per_user):
-        """Check that the conversion window dates make sense
+        """Check that the conversion window dates make sense.
 
-        We need min_days_per_user days of post-enrollment data per user.
+        We need `min_days_per_user` days of post-enrollment data per user.
         This places limits on how early we can run certain analyses.
         This method calculates and presents these limits.
+
+        Args:
+            today (str): The most recent day for which we have incomplete
+                data, e.g. '20190322'. Feel free to supply an older date
+                if the ETL is delayed or the experiment ended in the past.
+            min_days_per_user (int): The minimum number of days of
+                post-enrollment data required to have data for the user
+                for the entire conversion window.
         """
         slack = 1  # 1 day of slack: assume yesterday's data is not present
         last_enrollment_date = add_days(
@@ -255,13 +326,19 @@ class Experiment(object):
 
     def _get_telemetry_sanity_check_metrics(self, enrollments, df):
         """Return aggregations that check for problems with a client."""
+
+        # TODO: Once we know what form the metrics library will take,
+        # we should move the below metric definitions and documentation
+        # into it.
         return [
+
             # Check to see whether the client_id is also enrolled in other branches
             # E.g. indicates cloned profiles. Fraction of such users should be
             # small, and similar between branches.
             F.max(F.coalesce((
                 df.experiments[self.experiment_slug] != enrollments.branch
             ).astype('int'), F.lit(0))).alias('has_contradictory_branch'),
+
             # Check to see whether the client_id was sending data in the conversion
             # window that wasn't tagged as being part of the experiment. Indicates
             # either a client_id clash, or the client unenrolling. Fraction of such
@@ -271,13 +348,3 @@ class Experiment(object):
                 & F.isnull(df.experiments[self.experiment_slug])
             ).astype('int'), F.lit(0))).alias('has_non_enrolled_data'),
         ]
-
-    def check_consistency(self, enrollments, df):
-        """Check that the enrollments view is consistent with the data view
-
-        i.e.:
-        - no missing client_ids from either
-        - check for duplicate client_id values
-        """
-        # TODO: stub
-        raise NotImplementedError


### PR DESCRIPTION
The main practical change is that `.cache()` and `F.broadcast()` are now called on the `enrollments` DataFrame it is returned. If this proves problematic for certain usecases then we can make it optional or remove it, but I figured let's not add an option that we suspect no-one will ever use.

The other outward-facing change is that `get_enrollments()` has become a 'universal' method that returns an `enrollments` DataFrame both for pref flip and for addon experiments. In the future it would also be used for glean experiments. I figured a single entrypoint was more discoverable than separate methods for each method - plus this eliminates a few lines of repeated code.

The `check_consistency` stub method has been removed; I think consistency checks are going to have to live in another module since eventually there may be many of them and they smell different to this module's contents.