### PR TITLE
Use setuptools-scm to create versioned sdists

### DIFF
--- a/describe_revision.py
+++ b/describe_revision.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+# Helper for setuptools-scm.
+
+import datetime as dt
+import subprocess
+
+ref = subprocess.check_output("git describe --dirty --all --long --first-parent --match master".split()).strip().decode("utf-8")
+last_commit = subprocess.check_output('git show --format=format:%ct master'.split()).strip().decode("ascii")
+
+version_string = dt.datetime.utcfromtimestamp(int(last_commit)).strftime("%Y%m%d%H%M%S")
+print(ref.replace("heads/master", version_string))

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
+[bdist_wheel]
+# This runs unchanged in Python 2 and Python 3; there are no binary components
+universal = 1
+
 [flake8]
 max-line-length=88
 exclude=.git,__pycache__

--- a/setup.py
+++ b/setup.py
@@ -4,16 +4,16 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-import datetime
-
+import os.path
 from setuptools import find_packages, setup
+
+SETUP_PATH = os.path.dirname(os.path.abspath(__file__))
 
 
 setup(
     name="dscontrib",
-    version=datetime.datetime.now().strftime("%Y%m%d%H%M%S"),
-    author="Rob Hudson",
-    author_email="robhudson@mozilla.com",
+    author="Mozilla Data Science team",
+    author_email="fx-data-dev@mozilla.org",
     description="A Python library for Mozilla Data Science code snippets",
     url="https://github.com/mozilla/dscontrib",
     packages=find_packages(where="src"),
@@ -24,4 +24,6 @@ setup(
         "scipy",
         "mozanalysis"
     ],
+    setup_requires=["setuptools_scm"],
+    use_scm_version={"git_describe_command": os.path.join(SETUP_PATH, "describe_revision.py")},
 )


### PR DESCRIPTION
Felix was surprised when he installed dscontrib from sdist and it was versioned according to the install date. This is because setup.py just always uses the current time as the version number. When we prebuild a binary distribution, that gets fixed at build time -- but when we distribute a source distribution, build happens just before install, so it uses the install time instead.

Since we publish sdists, we'd really like the version numbers to be set according to something more reproducible than the time a bdist is built. The commit time of the last change to master seems like a good anchor.

setuptools-scm is a helper that records version information derived from git in sdists. It usually cares about tags, but we can wrap `git describe` to make it care about the last commit to master instead.